### PR TITLE
Fixed bool ! operation when applied to an unknown value

### DIFF
--- a/Core/Condition.lua
+++ b/Core/Condition.lua
@@ -114,10 +114,10 @@ function Condition:RunCondition(condition)
     end
 
     if opts.pet == true and not pet then
-        return false
+        return opTabler[opts.type][op](false)
     end
     if opts.arg == true and not arg then
-        return false
+        return opTabler[opts.type][op](false)
     end
     return opTabler[opts.type][op](fn(owner, pet, arg), value)
 end


### PR DESCRIPTION
### Bug
When using a command that returns a Boolean value (such as `.exists`, `.active`) that is paired with the `!` unary operator always returns false if the argument passed to the command could not be found.

### Example Use Case
```use(Dodge:312) [!enemy(#1).ability(Dive:564).usable]```
The above will use the ability `Dodge` if the enemy has `Dive` on cooldown. If the enemy does not have the ability dodge, then dodge will never be used, but should always be used.

If `Dive` could not be found as an ability on the enemy pet, `usable` returns false (which is correct) but the negation operator should still apply, causing the condition to be `true`.

### Testing
This change has been extensively tested and should be backwards compatible with any existing script.
