### PR TITLE
pet.type value parseID support

### DIFF
--- a/Core/Util.lua
+++ b/Core/Util.lua
@@ -124,7 +124,10 @@ local PET_TYPES = {} do
 end
 
 function Util.ParsePetType(value)
-    return value and PET_TYPES[lower(value)] or nil
+    if not value then 
+        return nil 
+    end
+    return PET_TYPES[lower(value)] or PET_TYPES[Util.ParseID(value)] or nil
 end
 
 local PET_QUALITIES = {} do


### PR DESCRIPTION
**Problem**

When writng scripts checking mostly enemy.type, but probably also self.type, one cant specify both name and number for pet type, only local pet type name or ID. Therefore the only way to write a script shareable to other localizations is defining numeric IDs.

**Example Use Case**

`ability(#1) [enemy.type = Undead:4]`

**Testing**

The change has been tested and should be backwards compatible with any existing script.