### PR TITLE
conditions: fix issue 26 / handling of non-existent pets/abilities

### DIFF
--- a/Core/Condition.lua
+++ b/Core/Condition.lua
@@ -113,13 +113,8 @@ function Condition:RunCondition(condition)
         error('Big Bang !!!!!!')
     end
 
-    if opts.pet == true and not pet then
-        return opTabler[opts.type][op](false)
-    end
-    if opts.arg == true and not arg then
-        return opTabler[opts.type][op](false)
-    end
-    return opTabler[opts.type][op](fn(owner, pet, arg), value)
+    local res = fn(owner, pet, arg)
+    return opTabler[opts.type][op](res, value)
 end
 
 function Condition:ParsePet(str)

--- a/Extension/Conditions.lua
+++ b/Extension/Conditions.lua
@@ -21,6 +21,9 @@ local function getOpponentActivePet(owner)
 end
 
 local function GetAbilityAttackModifier(owner, pet, ability)
+    if not pet or not ability then
+        return
+    end
     local abilityType, noStrongWeakHints = select(7, C_PetBattles.GetAbilityInfo(owner, pet, ability))
     if noStrongWeakHints then
         return
@@ -31,6 +34,10 @@ local function GetAbilityAttackModifier(owner, pet, ability)
     return C_PetBattles.GetAttackModifier(abilityType, opponentType)
 end
 
+local infinite = tonumber('inf')
+local function logical_max_health(owner, pet)
+    return pet and C_PetBattles.GetMaxHealth(owner, pet) or infinite
+end
 
 Addon:RegisterCondition('dead', { type = 'boolean', arg = false }, function(owner, pet)
     return C_PetBattles.GetHealth(owner, pet) == 0
@@ -43,12 +50,12 @@ end)
 
 
 Addon:RegisterCondition('hp.full', { type = 'boolean', arg = false }, function(owner, pet)
-    return C_PetBattles.GetHealth(owner, pet) == C_PetBattles.GetMaxHealth(owner, pet)
+    return C_PetBattles.GetHealth(owner, pet) == logical_max_health(owner, pet)
 end)
 
 
 Addon:RegisterCondition('hp.can_explode', { type = 'boolean', arg = false }, function(owner, pet)
-    return C_PetBattles.GetHealth(owner, pet) < floor(C_PetBattles.GetMaxHealth(getOpponentActivePet(owner)) * 0.4)
+    return pet and C_PetBattles.GetHealth(owner, pet) < floor(logical_max_health(getOpponentActivePet(owner)) * 0.4)
 end)
 
 
@@ -63,18 +70,18 @@ end)
 
 
 Addon:RegisterCondition('hpp', { type = 'compare', arg = false }, function(owner, pet)
-    return C_PetBattles.GetHealth(owner, pet) / C_PetBattles.GetMaxHealth(owner, pet) * 100
+    return C_PetBattles.GetHealth(owner, pet) / logical_max_health(owner, pet) * 100
 end)
 
 
 Addon:RegisterCondition('aura.exists', { type = 'boolean' }, function(owner, pet, aura)
-    return Util.FindAura(owner, pet, aura)
+    return aura and Util.FindAura(owner, pet, aura)
 end)
 
 
 Addon:RegisterCondition('aura.duration', { type = 'compare' }, function(owner, pet, aura)
     local owner, pet, index = Util.FindAura(owner, pet, aura)
-    if index then
+    if aura and index then
         return (select(3, C_PetBattles.GetAuraInfo(owner, pet, index)))
     end
     return 0
@@ -87,13 +94,13 @@ Addon:RegisterCondition('weather', { type = 'boolean', owner = false, pet = fals
     if aura then
         id, name = C_PetBattles.GetAbilityInfoByID(aura)
     end
-    return id == weather or name == weather
+    return weather and (id == weather or name == weather)
 end)
 
 
 Addon:RegisterCondition('weather.duration', { type = 'compare', owner = false, pet = false }, function(_, _, weather)
     local id, _, duration = C_PetBattles.GetAuraInfo(LE_BATTLE_PET_WEATHER, PET_BATTLE_PAD_INDEX, 1)
-    if id and (id == weather or select(2, C_PetBattles.GetAbilityInfoByID(id)) == weather) then
+    if weather and id and (id == weather or select(2, C_PetBattles.GetAbilityInfoByID(id)) == weather) then
         return duration
     end
     return 0
@@ -106,12 +113,14 @@ end)
 
 
 Addon:RegisterCondition('ability.usable', { type = 'boolean', argParse = Util.ParseAbility }, function(owner, pet, ability)
-    return (C_PetBattles.GetAbilityState(owner, pet, ability))
+    local isUsable, currentCooldown, currentLockdown = C_PetBattles.GetAbilityState(owner, pet, ability)
+    return ability and isUsable
 end)
 
 
 Addon:RegisterCondition('ability.duration', { type = 'compare', argParse = Util.ParseAbility }, function(owner, pet, ability)
-    return (select(2, C_PetBattles.GetAbilityState(owner, pet, ability)))
+    local isUsable, currentCooldown, currentLockdown = C_PetBattles.GetAbilityState(owner, pet, ability)
+    return ability and currentCooldown or infinite
 end)
 
 
@@ -141,7 +150,7 @@ Addon:RegisterCondition('round', { type = 'compare', pet = false, arg = false },
 end)
 
 Addon:RegisterCondition('played', { type = 'boolean', arg = false }, function(owner, pet)
-    return Played:IsPetPlayed(owner, pet)
+    return pet and Played:IsPetPlayed(owner, pet)
 end)
 
 Addon:RegisterCondition('speed', { type = 'compare', arg = false }, C_PetBattles.GetSpeed)
@@ -150,7 +159,7 @@ Addon:RegisterCondition('level', { type = 'compare', arg = false }, C_PetBattles
 
 
 Addon:RegisterCondition('level.max', { type = 'boolean', arg = false }, function(owner, pet)
-    return C_PetBattles.GetLevel(owner, pet) == 25
+    return pet and C_PetBattles.GetLevel(owner, pet) == 25
 end)
 
 
@@ -170,7 +179,7 @@ end)
 
 
 Addon:RegisterCondition('quality', { type = 'compare', arg = false, valueParse = Util.ParseQuality }, function(owner, pet)
-    return C_PetBattles.GetBreedQuality(owner, pet)
+    return pet and C_PetBattles.GetBreedQuality(owner, pet)
 end)
 
 


### PR DESCRIPTION
Assumes

```
test(expected: self(pet).dead) [ !self(pet).dead ]
test(expected: self(pet).hp == 0) [ self(pet).hp != 0 ]
test(expected: !self(pet).hp.full) [ self(pet).hp.full ]
test(expected: !self(pet).hp.can_explode) [ self(pet).hp.can_explode ]
-- no pet, no arg: hp.low
-- no pet, no arg: hp.high
test(expected: self(pet).hpp == 0) [ self(pet).hpp != 0 ]
test(expected: !self.aura(arg).exists) [ self.aura(arg).exists ]
test(expected: !self(#1).aura(arg).exists) [ self(#1).aura(arg).exists ]
test(expected: !self(pet).aura(arg).exists) [ self(pet).aura(arg).exists ]
test(expected: self.aura(arg).duration == 0) [ self.aura(arg).duration != 0 ]
test(expected: self(#1).aura(arg).duration == 0) [ self(#1).aura(arg).duration != 0 ]
test(expected: self(pet).aura(arg).duration == 0) [ self(pet).aura(arg).duration != 0 ]
test(expected: !weather(arg)) [ weather(arg) ]
test(expected: weather(arg).duration == 0) [ weather(arg).duration != 0 ]
test(expected: !self(pet).active) [ self(pet).active ]
test(expected: !self.ability(arg).usable) [ self.ability(arg).usable ]
test(expected: !self(#1).ability(arg).usable) [ self(#1).ability(arg).usable ]
test(expected: !self(pet).ability(arg).usable) [ self(pet).ability(arg).usable ]
test(expected: self.ability(arg).duration == inf) [ self.ability(arg).duration < 1000000 ]
test(expected: self(#1).ability(arg).duration == inf) [ self(#1).ability(arg).duration < 1000000 ]
test(expected: self(pet).ability(arg).duration == inf) [ self(pet).ability(arg).duration < 1000000 ]
test(expected: !self.ability(arg).strong) [ self.ability(arg).strong ]
test(expected: !self(#1).ability(arg).strong) [ self(#1).ability(arg).strong ]
test(expected: !self(pet).ability(arg).strong) [ self(pet).ability(arg).strong ]
test(expected: !self.ability(arg).weak) [ self.ability(arg).weak ]
test(expected: !self(#1).ability(arg).weak) [ self(#1).ability(arg).weak ]
test(expected: !self(pet).ability(arg).weak) [ self(pet).ability(arg).weak ]
test(expected: self.ability(arg).type !~ 1,2,3,4,5,6,7,8,9,10) [ self.ability(arg).type ~ 1,2,3,4,5,6,7,8,9,10 ]
test(expected: self(#1).ability(arg).type !~ 1,2,3,4,5,6,7,8,9,10) [ self(#1).ability(arg).type ~ 1,2,3,4,5,6,7,8,9,10 ]
test(expected: self(pet).ability(arg).type !~ 1,2,3,4,5,6,7,8,9,10) [ self(pet).ability(arg).type ~ 1,2,3,4,5,6,7,8,9,10 ]
-- no pet, no arg: round
test(expected: !self(pet).played) [ self(pet).played ]
test(expected: self(pet).speed == 0) [ self(pet).speed != 0 ]
test(expected: self(pet).power == 0) [ self(pet).power != 0 ]
test(expected: self(pet).level == 0) [ self(pet).level != 0 ]
test(expected: !self(pet).level.max) [ self(pet).level.max ]
-- no pet, no arg: speed.fast
-- no pet, no arg: speed.slow
test(expected: self(pet).type !~ 1,2,3,4,5,6,7,8,9,10) [ self(pet).type ~ 1,2,3,4,5,6,7,8,9,10 ]
test(expected: self(pet).quality !~ 1,2,3,4,5,6) [ self(pet).quality ~ 1,2,3,4,5,6 ]
test(expected: !self(pet).exists) [ self(pet).exists ]
test(expected: !self(pet).is(other)) [ self(pet).is(other) ]
test(expected: !self(pet).is(#1)) [ self(pet).is(#1) ]
test(expected: !self(#1).is(other)) [ self(#1).is(other) ]
test(expected: self(pet).id == 0) [ self(pet).id != 0 ]
test(passed)
```

to be the expected behavior and ensures that.

Note: previously, 
- `!self(pet).dead`
- `self.hp` and `self.hpp` is not 0
- `self(pet).aura(arg).duration` is not 0
- lua error because `self.ability(arg).duration < 1000000` is breaking (*the* issue)
- lua error because `self.ability(arg).type !~ 1,2,3,4,5,6,7,8,9,10)` is broken (the same reason)
- lua error because `self(pet).type ~ 1,2,3,4,5,6,7,8,9,10 ` is broken (same reason, again)