### PR TITLE
Implements 'collected' and 'trap' conditions

### DIFF
--- a/Extension/Conditions.lua
+++ b/Extension/Conditions.lua
@@ -187,3 +187,8 @@ end)
 Addon:RegisterCondition('id', { type = 'equality', pet = 1, arg = false }, function(owner, pet)
     return pet and C_PetBattles.GetPetSpeciesID(owner, pet) or 0
 end)
+
+Addon:RegisterCondition('collected', { type = 'boolean', arg = false }, function(owner, pet)
+    local name = select(2, C_PetBattles.GetName(owner, pet))
+    return select(2, C_PetJournal.FindPetIDByName(name)) ~= nil
+end)

--- a/Extension/Conditions.lua
+++ b/Extension/Conditions.lua
@@ -192,3 +192,8 @@ Addon:RegisterCondition('collected', { type = 'boolean', arg = false }, function
     local name = select(2, C_PetBattles.GetName(owner, pet))
     return select(2, C_PetJournal.FindPetIDByName(name)) ~= nil
 end)
+
+Addon:RegisterCondition('trap', { type = 'boolean', owner = false , pet = false, arg = false }, function()
+    local usable, err = C_PetBattles.IsTrapAvailable()
+    return usable or (not usable and err == 4)
+end)


### PR DESCRIPTION
Adds a simple 'collected' condition (eg. `enemy.collected`)

Would close #44 and close #21 

Also implements `trap` which checks if your trap can be used (or could be used if the enemy pet's health was low enough)

Allows for `catch [trap & !enemy.collected & enemy.hpp < 35]` etc.

These two conditions allow for automating decisions around swapping pets in/out for a capture team and dynamically handling throwing the trap.